### PR TITLE
Fix: Prevent duplicate robot spawn in Gazebo delay spawn and disable …

### DIFF
--- a/Fusion_URDF_Exporter_ROS2/core/launch_templates.py
+++ b/Fusion_URDF_Exporter_ROS2/core/launch_templates.py
@@ -218,86 +218,71 @@ def generate_launch_description():
 gazebo_sim_launch = """import os
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import IncludeLaunchDescription
-from launch.substitutions import LaunchConfiguration,PythonExpression
+from launch.actions import IncludeLaunchDescription, TimerAction
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.actions import Node
-from launch.actions import AppendEnvironmentVariable, DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
-from launch.actions import RegisterEventHandler
-from launch.event_handlers import OnProcessExit
 import xacro
 from os.path import join
 
 def generate_launch_description():
 
-    # Package Directories
     pkg_ros_gz_sim = get_package_share_directory('ros_gz_sim')
     pkg_ros_gz_rbot = get_package_share_directory('%s')
 
-    # Parse robot description from xacro
+
     robot_description_file = os.path.join(pkg_ros_gz_rbot, 'urdf', '%s.xacro')
     ros_gz_bridge_config = os.path.join(pkg_ros_gz_rbot, 'config', 'ros_gz_bridge_gazebo.yaml')
     
-    robot_description_config = xacro.process_file(
-        robot_description_file
-    )
+    robot_description_config = xacro.process_file(robot_description_file)
     robot_description = {'robot_description': robot_description_config.toxml()}
 
-    # Start Robot state publisher
+   
     robot_state_publisher = Node(
         package='robot_state_publisher',
         executable='robot_state_publisher',
         name='robot_state_publisher',
-        output='both',
+        output='screen',
         parameters=[robot_description],
     )
 
-    # Start Gazebo Sim
+   
     gazebo = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(join(pkg_ros_gz_sim, "launch", "gz_sim.launch.py")),
-        launch_arguments={
-            "gz_args" : '-r -v 4 empty.sdf'
-        }.items()
+        launch_arguments={"gz_args": "-r -v 4 empty.sdf"}.items()
     )
 
-    # Spawn Robot in Gazebo   
-    spawn = Node(
-        package='ros_gz_sim',
-        executable='create',
-        arguments=[
-            "-topic", "/robot_description",
-            "-name", "%s",
-            "-allow_renaming", "true",
-            "-z", "0.32",
-            "-x", "0.0",
-            "-y", "0.0",
-            "-Y", "0.0"
-        ],            
-        output='screen',
+    spawn_robot = TimerAction(
+        period=5.0,  
+        actions=[Node(
+            package='ros_gz_sim',
+            executable='create',
+            arguments=[
+                "-topic", "/robot_description",
+                "-name", "%s",
+                "-allow_renaming", "false",  # prevents "_1" duplicate
+                "-x", "0.0",
+                "-y", "0.0",
+                "-z", "0.32",
+                "-Y", "0.0"
+            ],
+            output='screen'
+        )]
     )
 
-    # Bridge ROS topics and Gazebo messages for establishing communication
-    start_gazebo_ros_bridge_cmd = Node(
+    ros_gz_bridge = Node(
         package='ros_gz_bridge',
         executable='parameter_bridge',
-        parameters=[{
-          'config_file': ros_gz_bridge_config,
-        }],
+        parameters=[{'config_file': ros_gz_bridge_config}],
         output='screen'
-      )      
-
-
-    return LaunchDescription(
-        [
-            # Nodes and Launches
-            gazebo,
-            spawn,
-            start_gazebo_ros_bridge_cmd,
-            robot_state_publisher,
-        ]
     )
-"""
 
+    return LaunchDescription([
+        gazebo,
+        spawn_robot,
+        ros_gz_bridge,
+        robot_state_publisher,
+    ])
+"""
 
 def get_display_launch_text(package_name, robot_name):
     return display_launch % (package_name, robot_name)


### PR DESCRIPTION
Description:
 Firstly i want to thank you for this package ..Currently, when launching the gazebo_sim launch file, the robot occasionally spawns twice  . This behavior occurs because the robot spawn node executes immediately, before Gazebo fully initializes, and -allow_renaming allows automatic name changes.

Fix implemented:

- Added a TimerAction with a 5-second delay before spawning the robot, ensuring Gazebo is fully ready.

- Set -allow_renaming to false to maintain a consistent robot name.

- Cleaned up the launch sequence for clarity: Gazebo → Spawn → ROS-Gazebo Bridge → Robot State Publisher.

Impact:

- Ensures only a single instance of the robot spawns in Gazebo.

- Prevents confusion and potential topic conflicts from duplicate robot entities.

- Compatible with existing ROS 2 and ros_gz_sim setups.

Testing:

 - Verified in Gazebo with the robot that only one robot instance appears.

 - Confirmed all relevant ROS topics (/tf, /odom, /joint_states) function correctly after the change.

Before the change:
<img width="1470" height="956" alt="Screenshot 2025-11-10 at 14 57 14" src="https://github.com/user-attachments/assets/4f0e821f-2907-478a-8b50-f75a8440dd7a" />

After the change: 
<img width="1470" height="956" alt="Screenshot 2025-11-10 at 15 33 23" src="https://github.com/user-attachments/assets/d7375d40-5b5e-4575-bbbe-fe36df5303b4" />

I will really appreciate your feedback . Thank you .

